### PR TITLE
Atualiza descrição da palestra de Eric Fraga

### DIFF
--- a/_speakers/eric-fraga.md
+++ b/_speakers/eric-fraga.md
@@ -6,7 +6,7 @@ talk_title: "The dark side of SEO: how adversaries hijack search results"
 talk_time: 15:40 - 16:30
 talk_stage: Palco secundário
 talk_description: |
-    A ideia da palestra é trazer o contexto em incidentes de segurança envolvendo Ransomware, quais tratativas são necessárias, cases de uso, posturas em war room, como a empresa consegue fazer tratativas proativas em relação a incidente de segurança no ambiente.
+    A ideia da palestra é trazer o contexto em incidentes de segurança envolvendo SEO poisoning, quais tratativas são necessárias, ataques de ransomware que utilizam SEO poisoning,cases de uso, , como a empresa consegue fazer tratativas proativas em relação a incidente de segurança no ambiente.
 bio: |
     CEO na RSquad Academy com 13 anos de experiência na área de tecnologia. Seu campo de atuação é em Incident Response & DFIR. Analista de CSIRT SR na SOLOR Tecnologia com formação em Tecnólogo em Redes de Computadores.
 ---


### PR DESCRIPTION
### Motivation
- Atualizar o perfil do palestrante para que a descrição da palestra aborde especificamente incidentes envolvendo SEO poisoning e ataques de ransomware que o utilizam.

### Description
- Substituído o parágrafo em `_speakers/eric-fraga.md` para mencionar "SEO poisoning", tratamentos necessários, ataques de ransomware que utilizam SEO poisoning e casos de uso proativos.

### Testing
- Verificada a alteração localmente com `git status --short` e `nl -ba _speakers/eric-fraga.md | sed -n '1,40p'`, e tentativa de executar `bundle exec jekyll serve --host 0.0.0.0 --port 4000` falhou porque o executável `jekyll` não está disponível no ambiente atual.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b1ef9a840832b8dfb597a46909447)