### PR TITLE
Add Código de Conduta page and navigation entry

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,3 +6,5 @@
   url: /speakers.html
 - title: Contato
   url: /contato.html
+- title: Código de Conduta
+  url: /codigo-de-conduta.html

--- a/codigo-de-conduta.html
+++ b/codigo-de-conduta.html
@@ -1,0 +1,282 @@
+---
+layout: default
+title: Código de Conduta
+footer_text: "&copy; 2025 - 2026 | Código de Conduta BSidesRJ"
+---
+<section class="py-16 px-4 text-white">
+    <div class="max-w-5xl mx-auto">
+        <div class="bg-black bg-opacity-60 backdrop-blur-md rounded-3xl border border-yellow-400 border-opacity-30 shadow-2xl overflow-hidden">
+            <div class="px-8 py-12 md:px-12 border-b border-white border-opacity-10 bg-gradient-to-r from-black via-gray-900 to-black">
+                <p class="uppercase tracking-[0.35em] text-sm text-yellow-400 mb-4">
+                    Code of Conduct
+                </p>
+                <h1 class="text-4xl md:text-5xl font-bold mb-6">
+                    Código de Conduta
+                </h1>
+                <p class="text-lg md:text-xl text-gray-200 leading-relaxed max-w-4xl">
+                    Este documento orienta a convivência em todos os
+                    espaços da comunidade BSidesRJ: grupos, redes
+                    sociais, lives, eventos e projetos. As regras se
+                    aplicam a participantes, público, palestrantes,
+                    organização e moderação.
+                </p>
+            </div>
+
+            <div class="px-8 py-10 md:px-12 space-y-10">
+                <section class="space-y-4">
+                    <h2 class="text-2xl font-semibold text-yellow-400">
+                        O que é Código de Conduta?
+                    </h2>
+                    <p class="text-gray-100 leading-8">
+                        É um conjunto de regras para orientar condutas e
+                        atividades de um grupo de pessoas, de acordo com
+                        seus princípios e objetivos. Essas regras devem
+                        ser cumpridas e levadas a sério por toda a
+                        comunidade.
+                    </p>
+                    <p class="text-gray-100 leading-8">
+                        Estamos abertas a sugestões e críticas
+                        construtivas quando relevantes.
+                    </p>
+                </section>
+
+                <section class="space-y-5">
+                    <h2 class="text-2xl font-semibold text-yellow-400">
+                        Nossa comunidade
+                    </h2>
+                    <p class="text-gray-100 leading-8">
+                        Queremos manter um ambiente seguro e acolhedor,
+                        independentemente de:
+                    </p>
+                    <ul class="space-y-3 list-disc list-inside text-gray-100 leading-8 marker:text-yellow-400">
+                        <li>Gênero, identidade de gênero ou expressão de gênero;</li>
+                        <li>Orientação sexual;</li>
+                        <li>Restrições físicas;</li>
+                        <li>
+                            Aparência física, incluindo, mas não limitada,
+                            ao tamanho do corpo;
+                        </li>
+                        <li>Etnia;</li>
+                        <li>Idade;</li>
+                        <li>Religião ou ausência de religião;</li>
+                        <li>
+                            Posicionamento político ou ausência de
+                            posicionamento político;
+                        </li>
+                        <li>
+                            Escolha de tecnologias para trabalho e/ou
+                            estudo;
+                        </li>
+                        <li>Tempo de experiência na área de tecnologia;</li>
+                        <li>
+                            Nível de conhecimento ou de dificuldade em
+                            qualquer assunto da área de tecnologia.
+                        </li>
+                    </ul>
+                </section>
+
+                <section class="grid gap-8 lg:grid-cols-2">
+                    <div class="rounded-2xl border border-white border-opacity-10 bg-white bg-opacity-5 p-6 space-y-4">
+                        <h2 class="text-2xl font-semibold text-yellow-400">
+                            Para entrar na nossa comunidade, você deve:
+                        </h2>
+                        <ul class="space-y-3 list-disc list-inside text-gray-100 leading-8 marker:text-yellow-400">
+                            <li>Concordar com este Código de Conduta;</li>
+                            <li>Seguir nossos princípios;</li>
+                            <li>
+                                Ter interesse na área de segurança da
+                                informação e na comunidade BSidesRJ.
+                            </li>
+                        </ul>
+                    </div>
+
+                    <div class="rounded-2xl border border-white border-opacity-10 bg-white bg-opacity-5 p-6 space-y-4">
+                        <h2 class="text-2xl font-semibold text-yellow-400">
+                            Como pessoa participante da nossa comunidade,
+                            você deve:
+                        </h2>
+                        <ul class="space-y-3 list-disc list-inside text-gray-100 leading-8 marker:text-yellow-400">
+                            <li>Concordar com este Código de Conduta;</li>
+                            <li>
+                                Interagir com as pessoas participantes da
+                                comunidade;
+                            </li>
+                            <li>
+                                Consumir, compartilhar e fortalecer o
+                                conteúdo disponibilizado.
+                            </li>
+                        </ul>
+                    </div>
+                </section>
+
+                <section class="space-y-5">
+                    <h2 class="text-2xl font-semibold text-yellow-400">
+                        Como pessoa participante desta comunidade, você
+                        concorda que:
+                    </h2>
+                    <ul class="space-y-3 list-disc list-inside text-gray-100 leading-8 marker:text-yellow-400">
+                        <li>
+                            Somos, coletiva e individualmente, pessoas
+                            comprometidas com segurança e inclusão;
+                        </li>
+                        <li>
+                            Adotamos política de tolerância zero para
+                            assédio, perseguição ou discriminação;
+                        </li>
+                        <li>
+                            Respeitamos limites, identidade e privacidade
+                            das pessoas;
+                        </li>
+                        <li>
+                            Nos abstemos de linguagem opressiva, como
+                            comentários sexistas, racistas, homofóbicos,
+                            transfóbicos, classistas ou capacitistas;
+                        </li>
+                        <li>
+                            Não permitimos tópicos ofensivos sob a
+                            justificativa de humor;
+                        </li>
+                        <li>
+                            Não permitimos conteúdo comercial ou captação
+                            de dados para oferta de gratuidades,
+                            preservando a privacidade das pessoas
+                            participantes.
+                        </li>
+                    </ul>
+                </section>
+
+                <section class="grid gap-8 lg:grid-cols-2">
+                    <div class="rounded-2xl border border-yellow-400 border-opacity-30 bg-yellow-400 bg-opacity-10 p-6 space-y-4">
+                        <h2 class="text-2xl font-semibold text-yellow-400">
+                            Boas práticas
+                        </h2>
+                        <ul class="space-y-3 list-disc list-inside text-gray-100 leading-8 marker:text-yellow-400">
+                            <li>Respeite as pessoas, independentemente de quem sejam;</li>
+                            <li>
+                                Seja gentil: todes começamos com dúvidas,
+                                então vamos orientar quem está no início
+                                ou em qualquer momento da carreira;
+                            </li>
+                            <li>
+                                Faça críticas construtivas quando
+                                necessário, sem ofensas;
+                            </li>
+                            <li>
+                                Busque respostas também em outras fontes
+                                de pesquisa e compartilhe conhecimento;
+                            </li>
+                            <li>
+                                Evite discussões do tipo tecnologia X é
+                                melhor que tecnologia Y: cada tecnologia
+                                tem seu propósito;
+                            </li>
+                            <li>Não pratique mansplaining;</li>
+                            <li>
+                                Errar faz parte do processo: reconhecer
+                                pontos de melhoria também é evolução.
+                            </li>
+                        </ul>
+                    </div>
+
+                    <div class="space-y-8">
+                        <div class="rounded-2xl border border-white border-opacity-10 bg-white bg-opacity-5 p-6 space-y-4">
+                            <h2 class="text-2xl font-semibold text-yellow-400">
+                                Nós trabalhamos ativamente para:
+                            </h2>
+                            <ul class="space-y-3 list-disc list-inside text-gray-100 leading-8 marker:text-yellow-400">
+                                <li>
+                                    Ser uma comunidade segura e agradável
+                                    para todas as pessoas;
+                                </li>
+                                <li>
+                                    Cultivar uma rede de suporte,
+                                    compartilhamento de conhecimento e
+                                    encorajamento;
+                                </li>
+                                <li>
+                                    Incentivar variadas formas de
+                                    expressão de maneira responsável.
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div class="rounded-2xl border border-red-400 border-opacity-30 bg-red-500 bg-opacity-10 p-6 space-y-4">
+                            <h2 class="text-2xl font-semibold text-red-300">
+                                Nós condenamos:
+                            </h2>
+                            <ul class="space-y-3 list-disc list-inside text-gray-100 leading-8 marker:text-red-300">
+                                <li>
+                                    Perseguição, doxxing e divulgação
+                                    indevida de dados privados;
+                                </li>
+                                <li>Ameaças e assédio de qualquer tipo;</li>
+                                <li>
+                                    Qualquer comportamento que comprometa
+                                    a segurança e a participação das
+                                    pessoas.
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="space-y-4 rounded-2xl border border-white border-opacity-10 bg-white bg-opacity-5 p-6">
+                    <p class="text-gray-100 leading-8">
+                        Essas atitudes não são aceitáveis. Se você não
+                        concorda com estas regras, cancele sua
+                        participação na comunidade.
+                    </p>
+                </section>
+
+                <section class="space-y-5">
+                    <h2 class="text-2xl font-semibold text-yellow-400">
+                        Consequências para desrespeito às regras
+                    </h2>
+                    <ul class="space-y-3 list-disc list-inside text-gray-100 leading-8 marker:text-yellow-400">
+                        <li>
+                            Publicações e mensagens fora deste Código de
+                            Conduta serão removidas;
+                        </li>
+                        <li>
+                            Você pode receber timeout ou banimento em
+                            espaços online e eventos, conforme o
+                            comportamento;
+                        </li>
+                        <li>
+                            Se sofrer abuso, assédio, discriminação ou
+                            desconforto, fale com a moderação;
+                        </li>
+                        <li>
+                            Se a pessoa reportada estiver na moderação,
+                            procure outra pessoa moderadora;
+                        </li>
+                        <li>
+                            Pontos não abordados ou ambíguos serão
+                            tratados junto à moderação.
+                        </li>
+                    </ul>
+                </section>
+
+                <section class="space-y-5">
+                    <h2 class="text-2xl font-semibold text-yellow-400">
+                        Referências
+                    </h2>
+                    <p class="text-gray-100 leading-8">
+                        Este código foi inspirado por documentos de
+                        outras comunidades:
+                    </p>
+                    <ul class="space-y-3 list-disc list-inside text-gray-100 leading-8 marker:text-yellow-400 break-words">
+                        <li><a href="https://github.com/feministech/feministech.github.io/blob/master/codigo-de-conduta.md" target="_blank" class="hover:text-yellow-300">feministech/codigo-de-conduta</a></li>
+                        <li><a href="https://github.com/training-center/sobre/blob/master/CONDUCT.md" target="_blank" class="hover:text-yellow-300">training-center/sobre/CONDUCT.md</a></li>
+                        <li><a href="https://womakerscode.org/codigo-de-conduta/" target="_blank" class="hover:text-yellow-300">WoMakersCode/codigo-de-conduta</a></li>
+                        <li><a href="https://github.com/AndroidStudyGroup/Code-Of-Conduct" target="_blank" class="hover:text-yellow-300">AndroidStudyGroup/Code-Of-Conduct</a></li>
+                        <li><a href="https://github.com/AndroidDevBR/Codigo-De-Conduta" target="_blank" class="hover:text-yellow-300">AndroidDevBR/Codigo-De-Conduta</a></li>
+                        <li><a href="https://rubyonrailsbrasil.com.br/conduta" target="_blank" class="hover:text-yellow-300">Ruby on Rails Brasil</a></li>
+                        <li><a href="https://pt-br.confcodeofconduct.com/" target="_blank" class="hover:text-yellow-300">Conf Code of Conduct (pt-BR)</a></li>
+                        <li><a href="https://github.com/caquicoders/codigodeconduta" target="_blank" class="hover:text-yellow-300">caquicoders/codigodeconduta</a></li>
+                    </ul>
+                </section>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
### Motivation
- Provide a localized Code of Conduct page for BSidesRJ, matching the visual style and structure of the site and the referenced example, so community expectations are explicit and accessible.
- Make the page discoverable from the main navigation on both desktop and mobile by updating the site navigation data.

### Description
- Add a new page `codigo-de-conduta.html` containing the full Código de Conduta content and BSidesRJ-styled layout with page front-matter and a page-specific `footer_text`.
- Update `_data/navigation.yml` to include a `Código de Conduta` entry so the page appears in main and mobile menus.
- No external skill from `/opt/codex/skills` was required for this change.

### Testing
- Ran `ruby -e 'require "yaml"; navigation = YAML.load_file("_data/navigation.yml"); abort("missing nav") unless navigation.any? { |item| item["url"] == "/codigo-de-conduta.html" }; content = File.read("codigo-de-conduta.html"); abort("missing title") unless content.include?("title: Código de Conduta"); puts "navigation and page metadata verified"'` and it succeeded.
- Confirmed the git change set and created a commit for the two modified files (`codigo-de-conduta.html` and `_data/navigation.yml`).
- Attempted site build with `bundle exec jekyll build`, but build could not be completed because `bundle install` failed during environment setup (Rubygems returned `403 Forbidden`), so full site build was not verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd748c7cb4832b8bab59bc747ef3d1)