### PR TITLE
Adjust Dayane Zimmerer talk time

### DIFF
--- a/_speakers/dayane-zimmerer.md
+++ b/_speakers/dayane-zimmerer.md
@@ -3,7 +3,7 @@ name: Dayane Zimmerer
 order: 10
 photo: /images/speakers/dayane-z.jpg
 talk_title: "A linguagem C - Como falar para que os C-levels nos entendam"
-talk_time: 14:00 - 14:50
+talk_time: 10:10 - 11:00
 talk_stage: Women Village
 talk_description: |
   Ensinar profissionais de Cyber a traduzir riscos tecnicos em impacto de negocio, alinhando a narrativa ao vocabulario executivo (C-Levels). O objetivo e que a seguranca seja vista como um habilitador do negocio e nao apenas um departamento tecnico.


### PR DESCRIPTION
### Motivation
- Align Dayane Zimmerer's speaker profile schedule with the official agenda.
- Ensure the profile displays `10:10 - 11:00` as the talk time.

### Description
- Updated the front matter in `_speakers/dayane-zimmerer.md` changing `talk_time` from `14:00 - 14:50` to `10:10 - 11:00`.
- No other fields or content were modified.
- The change is a single-line front-matter update.

### Testing
- Ran `rg -n "Dayane|Zimmerer|10:10|11hrs|11h|11:00" .` to locate schedule references in the repository.
- Inspected `_speakers/dayane-zimmerer.md` with `sed` to confirm the original and updated front matter.
- Executed a Python script to perform the replacement and verified the file now contains `talk_time: 10:10 - 11:00`.
- Produced a file diff to confirm the update is a single-line substitution with one insertion and one deletion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bea72e66a0832b9f260c4659c41bf8)