### PR TITLE
Ajusta horário da palestra de Abid Lohan

### DIFF
--- a/_speakers/abid-lohan.md
+++ b/_speakers/abid-lohan.md
@@ -3,7 +3,7 @@ name: Abid Lohan
 order: 5
 photo: /images/speakers/abid-lohan.jpg
 talk_title: Android Game Hacking
-talk_time: 11:00 - 11:50
+talk_time: 15:40 - 16:30
 talk_stage: Palco Principal
 talk_description: |
  A palestra Android Game Hacking introduz os conceitos essenciais do funcionamento do Android e das práticas de game hacking, mostrando como jogos podem ser manipulados quando não possuem boas proteções. Serão apresentadas técnicas de engenharia reversa, análise de requisições e os principais desafios impostos por mecanismos de segurança aplicados em jogos modernos. Para concluir, demonstrações práticas em jogos mobile bem conhecidos ilustram a aplicação real do conteúdo. Os participantes sairão com uma compreensão clara de como vulnerabilidades podem ser exploradas — e como esse conhecimento pode ajudar no desenvolvimento de jogos mais seguros.


### PR DESCRIPTION
### Motivation
- Alinhar o horário do perfil do palestrante Abid Lohan com o horário definido na agenda geral do evento.

### Description
- Atualiza o campo `talk_time` em ` _speakers/abid-lohan.md` de `11:00 - 11:50` para `15:40 - 16:30` para refletir o horário em `_data/schedule.yml`.

### Testing
- Verificado que o arquivo ` _speakers/abid-lohan.md` foi modificado e que a alteração aparece em `git diff`, e `git commit` e `git status --short` foram executados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2de424240832baafc2edab6e845b5)