### PR TITLE
Corrige horários dos perfis de palestrantes conforme agenda

### DIFF
--- a/_speakers/christiana-couto.md
+++ b/_speakers/christiana-couto.md
@@ -17,7 +17,7 @@ talks:
   - title: "De mãe para filha: a historia da minha trajetória profissional na área de segurança da informação"
     description: |
       As trajetórias de mãe e filha seguindo carreiras na área de TI, ao longo de meio século, representam as superações que abriram caminho para as mulheres entrararem no setor de TI com mais respeito e oportunidades. O avanço da participação feminina será apresentado com estatísticas, em paralelo ao exemplo real de um casal com dois filhos.
-    time: 10:10 - 11:00
+    time: 14:00 - 14:50
     stage: Palco Women Village
 bio: |
   Servidora pública federal no Instituto Nacional da Propriedade Industrial, doutoranda em Engenharia de Defesa no Instituto Militar de Engenharia e professora na Faculdade Infnet na graduação em Segurança Cibernética. Apaixonada por segurança da Informação, já trabalhou em multinacionais como analista em segurança da informação antes de seguir os passos de seus pais e passar para o serviço público. Christiana possui certificações como CISA, AWS Security Specialty e Azure Security Engineer.

--- a/_speakers/kizzy-macedo.md
+++ b/_speakers/kizzy-macedo.md
@@ -3,7 +3,7 @@ name: Kizzy Macedo Benjamin
 order: 6
 photo: /images/speakers/kizzy-macedo.png
 talk_title: "De 0 ao SOC: a curva real que ninguém ensina (e por que isso importa)"
-talk_time: 11:00 - 11:50
+talk_time: 14:00 - 14:50
 talk_stage: Palco principal
 talk_description: |
   Por que há tantas vagas em SOC e tão pouca gente entrando? Nesta palestra, você entende a verdadeira curva de aprendizado do Blue Team — uma ordem clara que começa pelos fundamentos (redes, sistemas e automação), evolui para práticas de SOC (SIEM, logs, MITRE) e chega ao que realmente gera entrevistas: um portfólio simples, mas verificável.


### PR DESCRIPTION
### Motivation

- Ajustar o horário do perfil de `Kizzy Macedo Benjamin` para corresponder ao horário definido em `_data/schedule.yml`.
- Garantir consistência entre a agenda geral e os metadados dos perfis de palestrantes, revisando outros perfis vinculados à agenda.

### Description

- Atualiza `talk_time` em `_speakers/kizzy-macedo.md` para `14:00 - 14:50`.
- Ajusta o tempo da segunda palestra em `talks` no arquivo `_speakers/christiana-couto.md` para `14:00 - 14:50`.
- Adicionei e usei um validador Ruby que compara `_data/schedule.yml` com os arquivos em `_speakers/*.md` para detectar e corrigir divergências.

### Testing

- Rodei o script Ruby que cruza `_data/schedule.yml` com `_speakers/*.md` e o resultado foi `OK: all speaker times match schedule`, indicando que todos os perfis agora estão consistentes com a agenda.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5bf15eb88832ba5389bf2387fb892)