### PR TITLE
Fix Oliveira Lima speaker page time to match schedule slot

### DIFF
--- a/_speakers/oliveira-lima.md
+++ b/_speakers/oliveira-lima.md
@@ -3,7 +3,7 @@ name: Oliveira Lima
 order: 2
 photo: /images/speakers/oliveira-lima.jpeg
 talk_title: OPSEC for Red Teams - operações clandestinas autorizadas
-talk_time: 10:10 - 11:00
+talk_time: 09:30 - 10:10
 talk_stage: Palco Principal
 talk_description: |
   Como costumo dizer: não simule a ameaça — seja a ameaça.


### PR DESCRIPTION
### Motivation
- Align speaker metadata with the canonical schedule to remove a mismatch where the speaker page listed `10:10 - 11:00` while the agenda shows `09:30 - 10:10`, which could confuse attendees and downstream consumers.

### Description
- Updated `talk_time` in `_speakers/oliveira-lima.md` from `10:10 - 11:00` to `09:30 - 10:10` to match the slot in `_data/schedule.yml`.

### Testing
- Verified the change via `git diff _speakers/oliveira-lima.md` and by inspecting `nl -ba _speakers/oliveira-lima.md | sed -n '1,20p'` and `_data/schedule.yml`, confirming the times now match and the diff contains only the intended single-line update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6cbc7cdf8832b9fd80310aabba172)